### PR TITLE
Unify menu rendering across managers

### DIFF
--- a/src/managers/menus/internal_manager.py
+++ b/src/managers/menus/internal_manager.py
@@ -11,6 +11,7 @@ from urllib.parse import quote
 from urllib3.util.retry import Retry
 from PIL import Image, ImageDraw, ImageFont
 from managers.base_manager import BaseManager  # Adjust import based on your project structure
+from utils.menu_renderer import render_list_menu
 
 class InternalManager(BaseManager):
     def __init__(self, display_manager, volumio_config, mode_manager, window_size=3, y_offset=0, line_spacing=16):
@@ -400,41 +401,17 @@ class InternalManager(BaseManager):
             menu_title = self.menu_stack[-1].get("menu_title", menu_title)
 
         self.logger.info(f"InternalManager: Displaying menu: {menu_title}")
-
-        visible_items = self.get_visible_window(self.current_menu_items)
-        self.logger.debug(f"InternalManager: Visible items: {visible_items}")
-
-        def draw(draw_obj):
-            y_position = self.y_offset
-
-            # Display the menu title
-            draw_obj.text(
-                (0, y_position),
-                menu_title[:20],  # Ensure the title fits the width
-                font=self.display_manager.fonts.get(self.font_key, ImageFont.load_default()),
-                fill="yellow"
-            )
-            y_position += self.line_spacing
-
-            # Display each menu item
-            for i, item in enumerate(visible_items):
-                actual_index = self.window_start_index + i
-                if actual_index >= len(self.current_menu_items):
-                    break  # Prevent index out of range
-
-                arrow = "-> " if actual_index == self.current_selection_index else "   "
-                item_title = item.get("title", "Unknown")
-                fill_color = "white" if actual_index == self.current_selection_index else "gray"
-
-                # No icon, just display the text
-                draw_obj.text(
-                    (0, y_position + i * self.line_spacing),
-                    f"{arrow}{item_title}",
-                    font=self.display_manager.fonts.get(self.font_key, ImageFont.load_default()),
-                    fill=fill_color
-                )
-
-        self.display_manager.draw_custom(draw)
+        self.window_start_index = render_list_menu(
+            display_manager=self.display_manager,
+            title=menu_title,
+            items=self.current_menu_items,
+            current_selection_index=self.current_selection_index,
+            window_start_index=self.window_start_index,
+            window_size=self.window_size,
+            y_offset=self.y_offset,
+            line_spacing=self.line_spacing,
+            font_key=self.font_key,
+        )
 
     def push_menu(self, menu_items, menu_title=""):
         """Push a new menu onto the stack and display it."""

--- a/src/managers/menus/library_manager.py
+++ b/src/managers/menus/library_manager.py
@@ -11,6 +11,7 @@ from urllib.parse import quote
 from urllib3.util.retry import Retry
 from PIL import Image, ImageDraw, ImageFont
 from managers.base_manager import BaseManager  # Adjust import based on your project structure
+from utils.menu_renderer import render_list_menu
 
 class LibraryManager(BaseManager):
     def __init__(self, display_manager, volumio_config, mode_manager, window_size=3, y_offset=0, line_spacing=16):
@@ -400,41 +401,17 @@ class LibraryManager(BaseManager):
             menu_title = self.menu_stack[-1].get("menu_title", menu_title)
 
         self.logger.info(f"LibraryManager: Displaying menu: {menu_title}")
-
-        visible_items = self.get_visible_window(self.current_menu_items)
-        self.logger.debug(f"LibraryManager: Visible items: {visible_items}")
-
-        def draw(draw_obj):
-            y_position = self.y_offset
-
-            # Display the menu title
-            draw_obj.text(
-                (0, y_position),
-                menu_title[:20],  # Ensure the title fits the width
-                font=self.display_manager.fonts.get(self.font_key, ImageFont.load_default()),
-                fill="yellow"
-            )
-            y_position += self.line_spacing
-
-            # Display each menu item
-            for i, item in enumerate(visible_items):
-                actual_index = self.window_start_index + i
-                if actual_index >= len(self.current_menu_items):
-                    break  # Prevent index out of range
-
-                arrow = "-> " if actual_index == self.current_selection_index else "   "
-                item_title = item.get("title", "Unknown")
-                fill_color = "white" if actual_index == self.current_selection_index else "gray"
-
-                # No icon, just display the text
-                draw_obj.text(
-                    (0, y_position + i * self.line_spacing),
-                    f"{arrow}{item_title}",
-                    font=self.display_manager.fonts.get(self.font_key, ImageFont.load_default()),
-                    fill=fill_color
-                )
-
-        self.display_manager.draw_custom(draw)
+        self.window_start_index = render_list_menu(
+            display_manager=self.display_manager,
+            title=menu_title,
+            items=self.current_menu_items,
+            current_selection_index=self.current_selection_index,
+            window_start_index=self.window_start_index,
+            window_size=self.window_size,
+            y_offset=self.y_offset,
+            line_spacing=self.line_spacing,
+            font_key=self.font_key,
+        )
 
     def push_menu(self, menu_items, menu_title=""):
         """Push a new menu onto the stack and display it."""

--- a/src/managers/menus/motherearth_manager.py
+++ b/src/managers/menus/motherearth_manager.py
@@ -1,4 +1,5 @@
 from managers.base_manager import BaseManager
+from utils.menu_renderer import render_list_menu
 import logging
 from PIL import ImageFont
 import threading
@@ -245,19 +246,17 @@ class MotherEarthManager(BaseManager):
     def display_menu(self):
         """Display the current station menu on the OLED."""
         self.logger.info("MotherEarthManager: Displaying station menu.")
-        visible_items = self.get_visible_window(self.current_menu_items)
-        self.logger.debug(f"MotherEarthManager: {len(visible_items)} items visible in current window.")
-        def draw_callback(draw_obj):
-            for i, item in enumerate(visible_items):
-                actual_index = self.window_start_index + i
-                arrow = "-> " if actual_index == self.current_selection_index else "   "
-                title = item.get("title", "Untitled")
-                font = self.font_bold if actual_index == self.current_selection_index else self.font
-                fill = "white" if actual_index == self.current_selection_index else "gray"
-                y = self.y_offset + i * self.line_spacing
-                draw_obj.text((10, y), f"{arrow}{title}", font=font, fill=fill)
-                self.logger.debug(f"MotherEarthManager: Drawn item '{title}' at y={y} with arrow='{arrow.strip()}'")
-        self.display_manager.draw_custom(draw_callback)
+        self.window_start_index = render_list_menu(
+            display_manager=self.display_manager,
+            title=self.mode_name.capitalize() if hasattr(self, "mode_name") else "MotherEarth",
+            items=self.current_menu_items,
+            current_selection_index=self.current_selection_index,
+            window_start_index=self.window_start_index,
+            window_size=self.window_size,
+            y_offset=self.y_offset,
+            line_spacing=self.line_spacing,
+            font_key=self.font_key,
+        )
 
     def display_no_stations_message(self):
         """Display a message when no stations are available."""

--- a/src/managers/menus/playlist_manager.py
+++ b/src/managers/menus/playlist_manager.py
@@ -1,4 +1,5 @@
 from managers.base_manager import BaseManager
+from utils.menu_renderer import render_list_menu
 import logging
 from PIL import ImageFont
 import threading
@@ -196,19 +197,17 @@ class PlaylistManager(BaseManager):
     def display_menu(self):
         """Display the current menu."""
         self.logger.info("PlaylistManager: Displaying current menu.")
-        visible_items = self.get_visible_window(self.current_menu_items)
-        def draw(draw_obj):
-            for i, item in enumerate(visible_items):
-                actual_index = self.window_start_index + i
-                arrow = "-> " if actual_index == self.current_selection_index else "   "
-                item_title = item.get("title", "Unknown")
-                draw_obj.text(
-                    (10, self.y_offset + i * self.line_spacing),
-                    f"{arrow}{item_title}",
-                    font=self.display_manager.fonts.get(self.font_key, ImageFont.load_default()),
-                    fill="white" if actual_index == self.current_selection_index else "gray"
-                )
-        self.display_manager.draw_custom(draw)
+        self.window_start_index = render_list_menu(
+            display_manager=self.display_manager,
+            title=self.mode_name.capitalize() if hasattr(self, "mode_name") else "Playlists",
+            items=self.current_menu_items,
+            current_selection_index=self.current_selection_index,
+            window_start_index=self.window_start_index,
+            window_size=self.window_size,
+            y_offset=self.y_offset,
+            line_spacing=self.line_spacing,
+            font_key=self.font_key,
+        )
 
     def get_visible_window(self, items):
         """Return the visible window of items."""

--- a/src/managers/menus/qobuz_manager.py
+++ b/src/managers/menus/qobuz_manager.py
@@ -1,5 +1,6 @@
 # src/managers/qobuz_manager.py
 from managers.base_manager import BaseManager
+from utils.menu_renderer import render_list_menu
 import logging
 from PIL import ImageFont
 import threading
@@ -225,22 +226,17 @@ class QobuzManager(BaseManager):
     def display_menu(self):
         """Display the current menu."""
         self.logger.info("QobuzManager: Displaying menu.")
-        visible_items = self.get_visible_window(self.current_menu_items)
-
-        def draw(draw_obj):
-            for i, item in enumerate(visible_items):
-                actual_index = self.window_start_index + i
-                arrow = "-> " if actual_index == self.current_selection_index else "   "
-                title = item['title']
-                self.logger.debug(f"QobuzManager: Drawing item {i}: {title}")
-                draw_obj.text(
-                    (10, self.y_offset + i * self.line_spacing),
-                    f"{arrow}{title}",
-                    font=self.display_manager.fonts.get(self.font_key, ImageFont.load_default()),
-                    fill="white" if actual_index == self.current_selection_index else "gray"
-                )
-
-        self.display_manager.draw_custom(draw)
+        self.window_start_index = render_list_menu(
+            display_manager=self.display_manager,
+            title=self.mode_name.capitalize(),
+            items=self.current_menu_items,
+            current_selection_index=self.current_selection_index,
+            window_start_index=self.window_start_index,
+            window_size=self.window_size,
+            y_offset=self.y_offset,
+            line_spacing=self.line_spacing,
+            font_key=self.font_key,
+        )
 
     def scroll_selection(self, direction):
         """Scroll through the menu items."""

--- a/src/managers/menus/radio_manager.py
+++ b/src/managers/menus/radio_manager.py
@@ -1,6 +1,7 @@
 # src/managers/radio_manager.py
 
 from managers.base_manager import BaseManager
+from utils.menu_renderer import render_list_menu
 import logging
 from PIL import ImageFont
 import threading

--- a/src/managers/menus/radioparadise_manager.py
+++ b/src/managers/menus/radioparadise_manager.py
@@ -1,4 +1,5 @@
 from managers.base_manager import BaseManager
+from utils.menu_renderer import render_list_menu
 import logging
 from PIL import ImageFont
 import threading
@@ -206,19 +207,17 @@ class RadioParadiseManager(BaseManager):
     def display_menu(self):
         """Display the current station menu on the OLED."""
         self.logger.info("RadioParadiseManager: Displaying station menu.")
-        visible_items = self.get_visible_window(self.current_menu_items)
-        self.logger.debug(f"RadioParadiseManager: {len(visible_items)} items visible in current window.")
-        def draw_callback(draw_obj):
-            for i, item in enumerate(visible_items):
-                actual_index = self.window_start_index + i
-                arrow = "-> " if actual_index == self.current_selection_index else "   "
-                title = item.get("title", "Untitled")
-                font = self.font_bold if actual_index == self.current_selection_index else self.font
-                fill = "white" if actual_index == self.current_selection_index else "gray"
-                y = self.y_offset + i * self.line_spacing
-                draw_obj.text((10, y), f"{arrow}{title}", font=font, fill=fill)
-                self.logger.debug(f"RadioParadiseManager: Drawn item '{title}' at y={y} with arrow='{arrow.strip()}'")
-        self.display_manager.draw_custom(draw_callback)
+        self.window_start_index = render_list_menu(
+            display_manager=self.display_manager,
+            title=self.mode_name.capitalize() if hasattr(self, "mode_name") else "RadioParadise",
+            items=self.current_menu_items,
+            current_selection_index=self.current_selection_index,
+            window_start_index=self.window_start_index,
+            window_size=self.window_size,
+            y_offset=self.y_offset,
+            line_spacing=self.line_spacing,
+            font_key=self.font_key,
+        )
 
     def display_no_stations_message(self):
         """Display a message when no stations are available."""

--- a/src/managers/menus/spotify_manager.py
+++ b/src/managers/menus/spotify_manager.py
@@ -1,5 +1,6 @@
 # src/managers/spotify_manager.py
 from managers.base_manager import BaseManager
+from utils.menu_renderer import render_list_menu
 import logging
 from PIL import ImageFont
 import threading
@@ -230,22 +231,17 @@ class SpotifyManager(BaseManager):
     def display_menu(self):
         """Display the current menu."""
         self.logger.info("SpotifyManager: Displaying menu.")
-        visible_items = self.get_visible_window(self.current_menu_items)
-
-        def draw(draw_obj):
-            for i, item in enumerate(visible_items):
-                actual_index = self.window_start_index + i
-                arrow = "-> " if actual_index == self.current_selection_index else "   "
-                title = item['title']
-                self.logger.debug(f"SpotifyManager: Drawing item {i}: {title}")
-                draw_obj.text(
-                    (10, self.y_offset + i * self.line_spacing),
-                    f"{arrow}{title}",
-                    font=self.display_manager.fonts.get(self.font_key, ImageFont.load_default()),
-                    fill="white" if actual_index == self.current_selection_index else "gray"
-                )
-
-        self.display_manager.draw_custom(draw)
+        self.window_start_index = render_list_menu(
+            display_manager=self.display_manager,
+            title=self.mode_name.capitalize() if hasattr(self, "mode_name") else "Spotify",
+            items=self.current_menu_items,
+            current_selection_index=self.current_selection_index,
+            window_start_index=self.window_start_index,
+            window_size=self.window_size,
+            y_offset=self.y_offset,
+            line_spacing=self.line_spacing,
+            font_key=self.font_key,
+        )
 
     def scroll_selection(self, direction):
         """Scroll through the menu items."""

--- a/src/managers/menus/tidal_manager.py
+++ b/src/managers/menus/tidal_manager.py
@@ -1,6 +1,7 @@
 # src/managers/tidal_manager.py
 
 from managers.base_manager import BaseManager
+from utils.menu_renderer import render_list_menu
 import logging
 from PIL import ImageFont
 import threading
@@ -245,22 +246,17 @@ class TidalManager(BaseManager):
     def display_menu(self):
         """Display the current menu."""
         self.logger.info("TidalManager: Displaying menu.")
-        visible_items = self.get_visible_window(self.current_menu_items)
-
-        def draw(draw_obj):
-            for i, item in enumerate(visible_items):
-                actual_index = self.window_start_index + i
-                arrow = "-> " if actual_index == self.current_selection_index else "   "
-                title = item['title']
-                self.logger.debug(f"TidalManager: Drawing item {i}: {title}")
-                draw_obj.text(
-                    (10, self.y_offset + i * self.line_spacing),
-                    f"{arrow}{title}",
-                    font=self.display_manager.fonts.get(self.font_key, ImageFont.load_default()),
-                    fill="white" if actual_index == self.current_selection_index else "gray"
-                )
-
-        self.display_manager.draw_custom(draw)
+        self.window_start_index = render_list_menu(
+            display_manager=self.display_manager,
+            title=self.mode_name.capitalize(),
+            items=self.current_menu_items,
+            current_selection_index=self.current_selection_index,
+            window_start_index=self.window_start_index,
+            window_size=self.window_size,
+            y_offset=self.y_offset,
+            line_spacing=self.line_spacing,
+            font_key=self.font_key,
+        )
 
     def scroll_selection(self, direction):
         """Scroll through the menu items."""

--- a/src/managers/menus/usb_library_manager.py
+++ b/src/managers/menus/usb_library_manager.py
@@ -1,6 +1,7 @@
 # usb_library_manager.py
 
 from managers.base_manager import BaseManager
+from utils.menu_renderer import render_list_menu
 import logging
 from PIL import ImageFont
 import threading
@@ -153,21 +154,17 @@ class USBLibraryManager(BaseManager):
     def display_menu(self):
         """Display the current menu."""
         self.logger.info("USBLibraryManager: Displaying current menu.")
-        visible_items = self.get_visible_window(self.current_menu_items)
-
-        def draw(draw_obj):
-            for i, item in enumerate(visible_items):
-                actual_index = self.window_start_index + i
-                arrow = "-> " if actual_index == self.current_selection_index else "   "
-                item_title = item.get("title", "Unknown")
-                draw_obj.text(
-                    (10, self.y_offset + i * self.line_spacing),
-                    f"{arrow}{item_title}",
-                    font=self.display_manager.fonts.get(self.font_key, ImageFont.load_default()),
-                    fill="white" if actual_index == self.current_selection_index else "gray"
-                )
-
-        self.display_manager.draw_custom(draw)
+        self.window_start_index = render_list_menu(
+            display_manager=self.display_manager,
+            title=self.mode_name.capitalize() if hasattr(self, "mode_name") else "USBLibrary",
+            items=self.current_menu_items,
+            current_selection_index=self.current_selection_index,
+            window_start_index=self.window_start_index,
+            window_size=self.window_size,
+            y_offset=self.y_offset,
+            line_spacing=self.line_spacing,
+            font_key=self.font_key,
+        )
 
     def get_visible_window(self, items):
         """Return the visible window of items."""

--- a/src/utils/menu_renderer.py
+++ b/src/utils/menu_renderer.py
@@ -1,0 +1,33 @@
+from PIL import ImageFont
+
+
+def compute_visible_window(items, current_selection_index, window_start_index, window_size):
+    """Compute the visible slice of items for scrolling menus."""
+    if current_selection_index < window_start_index:
+        window_start_index = current_selection_index
+    elif current_selection_index >= window_start_index + window_size:
+        window_start_index = current_selection_index - window_size + 1
+
+    window_start_index = max(0, window_start_index)
+    window_start_index = min(window_start_index, max(0, len(items) - window_size))
+    visible_items = items[window_start_index: window_start_index + window_size]
+    return visible_items, window_start_index
+
+
+def render_list_menu(display_manager, title, items, current_selection_index, window_start_index, window_size=4, y_offset=0, line_spacing=16, font_key="menu_font"):
+    """Render a simple text menu with a highlighted selection."""
+    font = display_manager.fonts.get(font_key, ImageFont.load_default())
+    visible_items, window_start_index = compute_visible_window(items, current_selection_index, window_start_index, window_size)
+
+    def draw(draw_obj):
+        y = y_offset
+        draw_obj.text((0, y), title[:20], font=font, fill="yellow")
+        y += line_spacing
+        for i, item in enumerate(visible_items):
+            actual_index = window_start_index + i
+            prefix = "-> " if actual_index == current_selection_index else "   "
+            fill = "white" if actual_index == current_selection_index else "gray"
+            item_title = item.get("title", "Untitled")
+            draw_obj.text((0, y + i * line_spacing), f"{prefix}{item_title[:20]}", font=font, fill=fill)
+    display_manager.draw_custom(draw)
+    return window_start_index


### PR DESCRIPTION
## Summary
- add `menu_renderer` utility with `render_list_menu`
- refactor multiple menu managers to use shared renderer
- ensure each menu shows a consistent title and list style

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ccc779b4483318ef0f5d9f36fe3d9